### PR TITLE
Exclude "node_modules" from linting.

### DIFF
--- a/src/File/Finder.php
+++ b/src/File/Finder.php
@@ -19,6 +19,7 @@ final class Finder extends BaseFinder
         $this
             ->files()
             ->name('*.twig')
+            ->exclude('node_modules')
             ->exclude('vendor');
     }
 }


### PR DESCRIPTION
## Description

Exclude "node_modules" from linting.

## Motivation

- https://github.com/VincentLanglet/Twig-CS-Fixer/issues/40