### PR TITLE
Add require with only sniff

### DIFF
--- a/src/Sniff/RequireWithOnlySniff.php
+++ b/src/Sniff/RequireWithOnlySniff.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigCsFixer\Sniff;
+
+use TwigCsFixer\Token\Token;
+use Webmozart\Assert\Assert;
+
+/**
+ * Ensure includes that pass additional variables always use "with ... only".
+ */
+final class RequireWithOnlySniff extends AbstractSniff
+{
+    protected function process(int $tokenPosition, array $tokens): void
+    {
+        $token = $tokens[$tokenPosition];
+
+        // If {% is found
+        if (!$this->isTokenMatching($token, Token::BLOCK_START_TYPE)) {
+            return;
+        }
+
+        // Find the next %}
+        $endTokenPosition = $this->findNext(Token::BLOCK_END_TYPE, $tokens, $tokenPosition);
+        Assert::notFalse($endTokenPosition, 'An open block must have a closer.');
+        $endToken = $tokens[$endTokenPosition];
+
+        // Check block is related to include
+        $includeTokenPosition = $this->findNextWithValue(Token::BLOCK_TAG_TYPE, $tokens, $tokenPosition, 'include');
+        if (false === $includeTokenPosition || $includeTokenPosition > $endTokenPosition) {
+            return;
+        }
+
+        // Check if there is a "with"
+        $withTokenPosition = $this->findNextWithValue(Token::NAME_TYPE, $tokens, $tokenPosition, 'with');
+        if (false === $withTokenPosition || $withTokenPosition > $endTokenPosition) {
+            return;
+        }
+
+        // Check if the last NAME token is "only"
+        $previousNameTokenPosition = $this->findPreviousWithValue(Token::NAME_TYPE, $tokens, $endTokenPosition, 'only');
+        if ($previousNameTokenPosition && $previousNameTokenPosition > $tokenPosition) {
+            return;
+        }
+
+        $fixer = $this->addFixableError(
+            'Includes passing additional variables must always use "with ... only".',
+            $endToken
+        );
+
+        if (null === $fixer) {
+            return;
+        }
+
+        $fixer->addContentBefore($endTokenPosition, 'only ');
+    }
+
+    private function findNextWithValue(int $type, array $tokens, int $tokenPosition, string $value): false|int
+    {
+        $position = $this->findNext($type, $tokens, $tokenPosition);
+        if (!$this->tokenHasValue($position, $tokens, $value)) {
+            return false;
+        }
+
+        return $position;
+    }
+
+    private function findPreviousWithValue(int $type, array $tokens, int $tokenPosition, string $value): false|int
+    {
+        $position = $this->findPrevious($type, $tokens, $tokenPosition);
+        if (!$this->tokenHasValue($position, $tokens, $value)) {
+            return false;
+        }
+
+        return $position;
+    }
+
+    private function tokenHasValue(bool|int $position, array $tokens, string $value): false|int
+    {
+        if (false === $position || !isset($tokens[$position])) {
+            return false;
+        }
+        $token = $tokens[$position];
+
+        if ($token->getValue() !== $value) {
+            return false;
+        }
+
+        return $position;
+    }
+}

--- a/tests/Sniff/RequireWithOnly/RequireWithOnlyTest.fixed.twig
+++ b/tests/Sniff/RequireWithOnly/RequireWithOnlyTest.fixed.twig
@@ -1,0 +1,9 @@
+{% include 'template.html' with {'foo': 'bar'} only %}
+
+{% include 'template.html'
+    with {
+    'foo': 'bar'
+    }
+only %}
+
+{% include 'template.html' %}

--- a/tests/Sniff/RequireWithOnly/RequireWithOnlyTest.php
+++ b/tests/Sniff/RequireWithOnly/RequireWithOnlyTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigCsFixer\Tests\Sniff\RequireWithOnly;
+
+use TwigCsFixer\Sniff\RequireWithOnlySniff;
+use TwigCsFixer\Tests\Sniff\AbstractSniffTestCase;
+
+final class RequireWithOnlyTest extends AbstractSniffTestCase
+{
+    public function testSniff(): void
+    {
+        $this->checkSniff(new RequireWithOnlySniff(), [
+            [1 => 48],
+            [7 => 1],
+        ]);
+    }
+}

--- a/tests/Sniff/RequireWithOnly/RequireWithOnlyTest.twig
+++ b/tests/Sniff/RequireWithOnly/RequireWithOnlyTest.twig
@@ -1,0 +1,9 @@
+{% include 'template.html' with {'foo': 'bar'} %}
+
+{% include 'template.html'
+    with {
+    'foo': 'bar'
+    }
+%}
+
+{% include 'template.html' %}

--- a/tests/Token/Tokenizer/Fixtures/test13.twig
+++ b/tests/Token/Tokenizer/Fixtures/test13.twig
@@ -1,0 +1,1 @@
+{% include 'template.html' with {'foo': 'bar'} only %}

--- a/tests/Token/Tokenizer/TokenizerTest.php
+++ b/tests/Token/Tokenizer/TokenizerTest.php
@@ -536,6 +536,32 @@ final class TokenizerTest extends TestCase
                 58 => Token::EOF_TYPE,
             ],
         ];
+
+        yield [
+            __DIR__.'/Fixtures/test13.twig',
+            [
+                0  => Token::BLOCK_START_TYPE,
+                1  => Token::WHITESPACE_TYPE,
+                2  => Token::BLOCK_TAG_TYPE,
+                3  => Token::WHITESPACE_TYPE,
+                4  => Token::STRING_TYPE,
+                5  => Token::WHITESPACE_TYPE,
+                6  => Token::NAME_TYPE,
+                7  => Token::WHITESPACE_TYPE,
+                8  => Token::PUNCTUATION_TYPE,
+                9  => Token::STRING_TYPE,
+                10 => Token::PUNCTUATION_TYPE,
+                11 => Token::WHITESPACE_TYPE,
+                12 => Token::STRING_TYPE,
+                13 => Token::PUNCTUATION_TYPE,
+                14 => Token::WHITESPACE_TYPE,
+                15 => Token::NAME_TYPE,
+                16 => Token::WHITESPACE_TYPE,
+                17 => Token::BLOCK_END_TYPE,
+                18 => Token::EOL_TYPE,
+                19 => Token::EOF_TYPE,
+            ],
+        ];
     }
 
     /**


### PR DESCRIPTION
Fixes #118 

This PR adds a "RequireWithOnly" sniff.

At my workplace we have a lot of templates and it becomes unclear where a used variable comes from.
By forcing ourselves to use `with ... only` we hope to always leave a trail.

If you use this in a Rule, be sure to mark it risky.
We plan to only use this in greenfield projects from the start.


```diff
-{% include 'template.html' with {'foo': 'bar'} %}
+{% include 'template.html' with {'foo': 'bar'} only %}
```