### PR TITLE
Handle TwigComponent `props` tag

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -7,6 +7,7 @@
         "Symfony\\Bridge\\Twig\\TokenParser\\TransDefaultDomainTokenParser",
         "Symfony\\Bridge\\Twig\\TokenParser\\TransTokenParser",
         "Symfony\\UX\\TwigComponent\\TwigComponentBundle",
+        "Symfony\\UX\\TwigComponent\\Twig\\PropsTokenParser",
         "Twig\\Extra\\Cache\\TokenParser\\CacheTokenParser"
     ]
 }

--- a/composer.json
+++ b/composer.json
@@ -58,8 +58,8 @@
     ],
     "config": {
         "allow-plugins": {
-            "infection/extension-installer": true,
-            "ergebnis/composer-normalize": true
+            "ergebnis/composer-normalize": true,
+            "infection/extension-installer": true
         },
         "sort-packages": true
     }

--- a/src/Environment/StubbedEnvironment.php
+++ b/src/Environment/StubbedEnvironment.php
@@ -9,6 +9,7 @@ use Symfony\Bridge\Twig\TokenParser\FormThemeTokenParser;
 use Symfony\Bridge\Twig\TokenParser\StopwatchTokenParser;
 use Symfony\Bridge\Twig\TokenParser\TransDefaultDomainTokenParser;
 use Symfony\Bridge\Twig\TokenParser\TransTokenParser;
+use Symfony\UX\TwigComponent\Twig\PropsTokenParser;
 use Symfony\UX\TwigComponent\TwigComponentBundle;
 use Twig\Environment;
 use Twig\Extension\ExtensionInterface;
@@ -74,6 +75,9 @@ final class StubbedEnvironment extends Environment
         }
         if (class_exists(TwigComponentBundle::class)) {
             $this->addTokenParser(new ComponentTokenParser());
+            if (class_exists(PropsTokenParser::class)) {
+                $this->addTokenParser(new PropsTokenParser());
+            }
         }
 
         foreach ($customTwigExtensions as $customTwigExtension) {

--- a/src/Environment/StubbedEnvironment.php
+++ b/src/Environment/StubbedEnvironment.php
@@ -76,6 +76,7 @@ final class StubbedEnvironment extends Environment
         if (class_exists(TwigComponentBundle::class)) {
             $this->addTokenParser(new ComponentTokenParser());
             if (class_exists(PropsTokenParser::class)) {
+                /** @psalm-suppress InternalClass */
                 $this->addTokenParser(new PropsTokenParser());
             }
         }

--- a/tests/Environment/Fixtures/props_tag.html.twig
+++ b/tests/Environment/Fixtures/props_tag.html.twig
@@ -1,0 +1,3 @@
+{% props foo = 'foo', bar %}
+
+{{ foo }}

--- a/tests/Environment/StubbedEnvironmentTest.php
+++ b/tests/Environment/StubbedEnvironmentTest.php
@@ -11,6 +11,7 @@ use Symfony\Bridge\Twig\Node\StopwatchNode;
 use Symfony\Bridge\Twig\Node\TransDefaultDomainNode;
 use Symfony\Bridge\Twig\Node\TransNode;
 use Symfony\UX\TwigComponent\Twig\ComponentLexer;
+use Symfony\UX\TwigComponent\Twig\PropsTokenParser;
 use Twig\Extra\Cache\Node\CacheNode;
 use Twig\Extra\Cache\TokenParser\CacheTokenParser;
 use Twig\Node\TextNode;
@@ -150,6 +151,25 @@ final class StubbedEnvironmentTest extends TestCase
 
         $env = new StubbedEnvironment();
         $source = new Source($content, 'component_tag.html.twig');
+
+        $env->parse($env->tokenize($source));
+    }
+
+    public function testParsePropsTag(): void
+    {
+        if (!class_exists(ComponentLexer::class)) {
+            static::markTestSkipped('symfony/ux-twig-component is required');
+        }
+
+        if (!class_exists(PropsTokenParser::class)) {
+            static::markTestSkipped('The props tag was added in TwigComponent 2.11.');
+        }
+
+        $content = file_get_contents(__DIR__.'/Fixtures/props_tag.html.twig');
+        static::assertNotFalse($content);
+
+        $env = new StubbedEnvironment();
+        $source = new Source($content, 'props_tag.html.twig');
 
         $env->parse($env->tokenize($source));
     }


### PR DESCRIPTION
This PR add compatibility with the [`props`](https://symfony.com/bundles/ux-twig-component/current/index.html#anonymous-components-1) tag introduced in Twig Component 2.11, which allows to define properties for anonymous components.

```twig
{# templates/components/Button.html.twig #}
{% props icon = null, label %}

<button>
    {{ label }}
    {% if icon %}
        <span class="fa-solid fa-{{ icon }}"></span>
    {% endif %}
</button>
```

