### PR TITLE
Added checkstyle reporting.

### DIFF
--- a/src/Report/Reporter/CheckstyleReporter.php
+++ b/src/Report/Reporter/CheckstyleReporter.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigCsFixer\Report\Reporter;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use TwigCsFixer\Report\Report;
+use TwigCsFixer\Report\SniffViolation;
+
+/**
+ * Human-readable output with context.
+ */
+final class CheckstyleReporter implements ReporterInterface
+{
+    public const NAME = 'checkstyle';
+
+    public function display(OutputInterface $output, Report $report, ?string $level = null): void
+    {
+        $checkstyle = new \SimpleXMLElement('<checkstyle version="1.0.0"/>');
+
+        foreach ($report->getFiles() as $file) {
+            $fileMessages = $report->getMessages($file, $level);
+            if (\count($fileMessages) > 0) {
+                $filenode = $checkstyle->addChild('file');
+                $filenode->addAttribute('name', $file);
+
+                foreach ($fileMessages as $message) {
+                    $violation = $filenode->addChild('violation');
+                    $violation->addAttribute('column', (string) $message->getLinePosition());
+                    $violation->addAttribute('line', (string) $message->getLine());
+                    $violation->addAttribute('severity', strtolower(SniffViolation::getLevelAsString($message->getLevel())));
+                    $violation->addAttribute('message', $message->getMessage());
+                }
+            }
+        }
+
+        $output->writeln($checkstyle->asXML());
+    }
+}

--- a/src/Report/ReporterFactory.php
+++ b/src/Report/ReporterFactory.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use TwigCsFixer\Report\Reporter\NullReporter;
 use TwigCsFixer\Report\Reporter\ReporterInterface;
 use TwigCsFixer\Report\Reporter\TextReporter;
+use TwigCsFixer\Report\Reporter\CheckstyleReporter;
 
 final class ReporterFactory
 {
@@ -16,6 +17,7 @@ final class ReporterFactory
         return match ($format) {
             NullReporter::NAME => new NullReporter(),
             TextReporter::NAME => new TextReporter(),
+            CheckstyleReporter::NAME => new CheckstyleReporter(),
             default            => throw new InvalidArgumentException(
                 sprintf('No reporter supports the format "%s".', $format)
             ),


### PR DESCRIPTION
Thanks for setting up the reporting functionality, that was quick!

Here's my initial attempt at the checkstyle reporting implementation (just went off of what the twigcs package was doing).  It's currently missing the source in the XML which is optional but might be nice to know the rule that caused the violation.  Not sure how big of a lift it would be to add that to the SniffViolation.