### PR TITLE
Remove 'ordered_imports' rule from .php-cs-fixer.php

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -53,10 +53,6 @@ $rules = [
     'no_useless_else'                                  => true,
     'nullable_type_declaration_for_default_null_value' => true,
     'operator_linebreak'                               => true,
-    'ordered_imports'                                  => [
-        'sort_algorithm' => 'alpha',
-        'imports_order'  => ['class', 'function', 'const'],
-    ],
     'php_unit_test_case_static_method_calls'           => true,
     'phpdoc_add_missing_param_annotation'              => true,
     'phpdoc_no_empty_return'                           => true,


### PR DESCRIPTION
Defined the same way in @Symfony RuleSet ([... by you](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/6712) 😄 )

Ref: https://cs.symfony.com/doc/rules/import/ordered_imports.html
```
@Symfony with config:

['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha']
```

Removed:

```diff
-    'ordered_imports'                                  => [
-        'sort_algorithm' => 'alpha',
-        'imports_order'  => ['class', 'function', 'const'],
-    ],
```