### PR TITLE
feat: add `IncludeFunctionRule` in default standard fixer

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,6 +7,7 @@ By default, the twig-cs-fixer standard is enabled with the twig coding standard 
 - `BlankEOFRule`: ensures that files end with one blank line.
 - `BlockNameSpacingRule`: ensures there is one space before and after block names.
 - `EmptyLinesRule`: ensures that 2 empty lines do not follow each other.
+- `IncludeFunctionRule`: ensures that include function is used instead of function tag.
 - `IndentRule`: ensures that files are not indented with tabs.
 - `TrailingCommaSingleLineRule`: ensures that single-line arrays, objects and argument lists do not have a trailing comma.
 - `TrailingSpaceRule`: ensures that files have no trailing spaces.

--- a/src/Standard/TwigCsFixer.php
+++ b/src/Standard/TwigCsFixer.php
@@ -25,7 +25,7 @@ final class TwigCsFixer implements StandardInterface
             new BlankEOFRule(),
             new BlockNameSpacingRule(),
             new EmptyLinesRule(),
-            new IncludeFunctionRule();
+            new IncludeFunctionRule(),
             new IndentRule(),
             new SingleQuoteRule(),
             new TrailingCommaSingleLineRule(),

--- a/src/Standard/TwigCsFixer.php
+++ b/src/Standard/TwigCsFixer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TwigCsFixer\Standard;
 
 use TwigCsFixer\Rules\Delimiter\BlockNameSpacingRule;
+use TwigCsFixer\Rules\Function\IncludeFunctionRule;
 use TwigCsFixer\Rules\Punctuation\TrailingCommaSingleLineRule;
 use TwigCsFixer\Rules\String\SingleQuoteRule;
 use TwigCsFixer\Rules\Whitespace\BlankEOFRule;
@@ -24,6 +25,7 @@ final class TwigCsFixer implements StandardInterface
             new BlankEOFRule(),
             new BlockNameSpacingRule(),
             new EmptyLinesRule(),
+            new IncludeFunctionRule();
             new IndentRule(),
             new SingleQuoteRule(),
             new TrailingCommaSingleLineRule(),

--- a/tests/Standard/TwigCsFixerTest.php
+++ b/tests/Standard/TwigCsFixerTest.php
@@ -7,6 +7,7 @@ namespace TwigCsFixer\Tests\Standard;
 use PHPUnit\Framework\TestCase;
 use TwigCsFixer\Rules\Delimiter\BlockNameSpacingRule;
 use TwigCsFixer\Rules\Delimiter\DelimiterSpacingRule;
+use TwigCsFixer\Rules\Function\IncludeFunctionRule;
 use TwigCsFixer\Rules\Operator\OperatorNameSpacingRule;
 use TwigCsFixer\Rules\Operator\OperatorSpacingRule;
 use TwigCsFixer\Rules\Punctuation\PunctuationSpacingRule;
@@ -34,6 +35,7 @@ final class TwigCsFixerTest extends TestCase
             new BlankEOFRule(),
             new BlockNameSpacingRule(),
             new EmptyLinesRule(),
+            new IncludeFunctionRule(),
             new IndentRule(),
             new SingleQuoteRule(),
             new TrailingCommaSingleLineRule(),


### PR DESCRIPTION
hey, 
I know there is https://github.com/VincentLanglet/Twig-CS-Fixer/blob/main/docs/configuration.md
but I see a lot of codebase going to this, which is more correct in twig 

wdyt of it being standard? 