### PR TITLE
Add flexibility on snake case

### DIFF
--- a/src/Util/StringUtil.php
+++ b/src/Util/StringUtil.php
@@ -8,9 +8,20 @@ use Symfony\Component\String\UnicodeString;
 
 class StringUtil
 {
+    /**
+     * @see UnicodeString::camel()
+     * @see UnicodeString::snake()
+     */
     public static function toSnakeCase(string $string): string
     {
-        return (new UnicodeString($string))->snake()->toString();
+        return (new UnicodeString($string))
+            ->replaceMatches('/[^\pL_0-9]++/u', '_')
+            ->replaceMatches('/(\p{Lu}+)(\p{Lu}\p{Ll})/u', '\1_\2')
+            ->replaceMatches('/([\p{Ll}0-9])(\p{Lu})/u', '\1_\2')
+            ->replaceMatches('/_+/', '_')
+            ->trim('_')
+            ->lower()
+            ->toString();
     }
 
     public static function toCamelCase(string $string): string
@@ -25,6 +36,6 @@ class StringUtil
 
     public static function toKebabCase(string $string): string
     {
-        return (new UnicodeString($string))->snake()->replace('_', '-')->toString();
+        return str_replace('_', '-', self::toSnakeCase($string));
     }
 }

--- a/tests/Rules/File/DirectoryName/DirectoryNameRuleTest.php
+++ b/tests/Rules/File/DirectoryName/DirectoryNameRuleTest.php
@@ -80,6 +80,14 @@ final class DirectoryNameRuleTest extends AbstractRuleTestCase
             ],
             __DIR__.'/templates/_directory_name_rule_test/DirectoryNameRuleTest.twig'
         );
+
+        $this->checkRule(
+            new DirectoryNameRule(baseDirectory: __DIR__.'/templates', optionalPrefix: '_'),
+            [
+                'DirectoryName.Error' => 'The directory name must use snake_case; expected _directory_name_rule_test.',
+            ],
+            __DIR__.'/templates/_directoryNameRuleTest/DirectoryNameRuleTest.twig'
+        );
     }
 
     public function testRulePascalCase(): void

--- a/tests/Rules/File/DirectoryName/templates/_directoryNameRuleTest/DirectoryNameRuleTest.twig
+++ b/tests/Rules/File/DirectoryName/templates/_directoryNameRuleTest/DirectoryNameRuleTest.twig
@@ -1,0 +1,1 @@
+Nothing

--- a/tests/Util/StringUtilTest.php
+++ b/tests/Util/StringUtilTest.php
@@ -28,6 +28,10 @@ class StringUtilTest extends TestCase
         yield ['foo-bar', 'foo_bar'];
         yield ['FooBar', 'foo_bar'];
         yield ['FOOBar', 'foo_bar'];
+        yield ['foo_bar1', 'foo_bar1'];
+        yield ['foo_bar_1', 'foo_bar_1'];
+        yield ['foo__bar', 'foo_bar'];
+        yield ['_foo_bar_', 'foo_bar'];
     }
 
     /**
@@ -49,6 +53,10 @@ class StringUtilTest extends TestCase
         yield ['foo-bar', 'fooBar'];
         yield ['FooBar', 'fooBar'];
         yield ['FOOBar', 'fooBar'];
+        yield ['foo_bar1', 'fooBar1'];
+        yield ['foo_bar_1', 'fooBar1'];
+        yield ['foo__bar', 'fooBar'];
+        yield ['_foo_bar_', 'fooBar'];
     }
 
     /**
@@ -70,6 +78,10 @@ class StringUtilTest extends TestCase
         yield ['foo-bar', 'FooBar'];
         yield ['FooBar', 'FooBar'];
         yield ['FOOBar', 'FOOBar'];
+        yield ['foo_bar1', 'FooBar1'];
+        yield ['foo_bar_1', 'FooBar1'];
+        yield ['foo__bar', 'FooBar'];
+        yield ['_foo_bar_', 'FooBar'];
     }
 
     /**
@@ -91,5 +103,9 @@ class StringUtilTest extends TestCase
         yield ['foo-bar', 'foo-bar'];
         yield ['FooBar', 'foo-bar'];
         yield ['FOOBar', 'foo-bar'];
+        yield ['foo_bar1', 'foo-bar1'];
+        yield ['foo_bar_1', 'foo-bar-1'];
+        yield ['foo__bar', 'foo-bar'];
+        yield ['_foo_bar_', 'foo-bar'];
     }
 }


### PR DESCRIPTION
Support both `foo_bar_1` and `foo_bar1`.