### PR TITLE
Update verbosity level of cache notice to prevent inclusion in output report

### DIFF
--- a/src/Command/TwigCsFixerCommand.php
+++ b/src/Command/TwigCsFixerCommand.php
@@ -111,7 +111,7 @@ final class TwigCsFixerCommand extends Command
 
         $cacheFile = $config->getCacheFile();
         if (null !== $cacheFile && is_file($cacheFile)) {
-            $output->writeln(sprintf('Using cache file "%s".', $cacheFile));
+            $output->writeln(sprintf('Using cache file "%s".', $cacheFile), OutputInterface::OUTPUT_NORMAL | OutputInterface::VERBOSITY_DEBUG);
         }
 
         return $config;


### PR DESCRIPTION
When using the reporting combined with the cache, the output will contain a line `Using cache file ...` before the actual report starts, corrupting the formatting (example when using junit as output):
```xml
Using cache file ".twig-cs-fixer.cache".
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
  <testsuite name="Twig CS Fixer" tests="1" failures="0">
    <testcase name="All OK">
    </testcase>
  </testsuite>
</testsuites>
```
This PR updates the verbosity level, so the cache message will only be shown when the command is run with `-vvv`. The report is then usable:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
  <testsuite name="Twig CS Fixer" tests="1" failures="0">
    <testcase name="All OK">
    </testcase>
  </testsuite>
</testsuites>
```