### PR TITLE
Add example code to demonstrate how to set templates-folder

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,7 +73,7 @@ If you want a more sophisticated rule, you can configure it in the config file:
 <?php
 
 $finder = new TwigCsFixer\File\Finder();
-$finder->in(__DIR__.'/templates'); // only lint files in the given directory
+$finder->in('templates');
 $finder->exclude('myCustomDirectory');
 
 $config = new TwigCsFixer\Config\Config();

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,6 +73,7 @@ If you want a more sophisticated rule, you can configure it in the config file:
 <?php
 
 $finder = new TwigCsFixer\File\Finder();
+$finder->in(__DIR__.'/templates'); // only lint files in the given directory
 $finder->exclude('myCustomDirectory');
 
 $config = new TwigCsFixer\Config\Config();


### PR DESCRIPTION
The documentation is missing some example code which demonstrates how to set the templates folder (**Files** section). In a common PHP project I usually have my Twig templates located in a sub-folder, e.g. `templates` and I don't want Twig-CS-Fixer to lint all the files in the current directory, as [this part suggests](https://github.com/VincentLanglet/Twig-CS-Fixer/blob/main/docs/configuration.md#files).