### PR TITLE
Introduce NodeRuleInterface

### DIFF
--- a/src/Cache/Signature.php
+++ b/src/Cache/Signature.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TwigCsFixer\Cache;
 
 use TwigCsFixer\Rules\ConfigurableRuleInterface;
+use TwigCsFixer\Rules\Node\ConfigurableNodeRuleInterface;
 use TwigCsFixer\Ruleset\Ruleset;
 
 final class Signature
@@ -26,7 +27,7 @@ final class Signature
     ): self {
         $rules = [];
         foreach ($ruleset->getRules() as $rule) {
-            $rules[$rule::class] = $rule instanceof ConfigurableRuleInterface
+            $rules[$rule::class] = $rule instanceof ConfigurableRuleInterface || $rule instanceof ConfigurableNodeRuleInterface
                 ? $rule->getConfiguration()
                 : null;
         }

--- a/src/Rules/Node/AbstractNodeRule.php
+++ b/src/Rules/Node/AbstractNodeRule.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigCsFixer\Rules\Node;
+
+use Twig\Environment;
+use Twig\Node\Node;
+use TwigCsFixer\Report\Report;
+use TwigCsFixer\Report\Violation;
+use TwigCsFixer\Report\ViolationId;
+
+abstract class AbstractNodeRule implements NodeRuleInterface
+{
+    private ?Report $report = null;
+
+    private ?string $filePath = null;
+
+    /**
+     * @var list<ViolationId>
+     */
+    private array $ignoredViolations = [];
+
+    public function getName(): string
+    {
+        return static::class;
+    }
+
+    public function getShortName(): string
+    {
+        $shortName = (new \ReflectionClass($this))->getShortName();
+
+        return str_ends_with($shortName, 'Rule') ? substr($shortName, 0, -4) : $shortName;
+    }
+
+    public function enterFile(Report $report, string $filePath, array $ignoredViolations = []): void
+    {
+        $this->report = $report;
+        $this->filePath = $filePath;
+        $this->ignoredViolations = $ignoredViolations;
+    }
+
+    public function enterNode(Node $node, Environment $env): Node
+    {
+        return $node;
+    }
+
+    public function leaveNode(Node $node, Environment $env): Node
+    {
+        return $node;
+    }
+
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
+    protected function addWarning(string $message, Node $node, ?string $messageId = null): bool
+    {
+        return $this->addMessage(
+            Violation::LEVEL_WARNING,
+            $message,
+            $node->getTemplateName(),
+            $node->getTemplateLine(),
+            null,
+            $messageId,
+        );
+    }
+
+    protected function addFileWarning(string $message, Node $node, ?string $messageId = null): bool
+    {
+        return $this->addMessage(
+            Violation::LEVEL_WARNING,
+            $message,
+            $node->getTemplateName(),
+            $node->getTemplateLine(),
+            null,
+            $messageId,
+        );
+    }
+
+    protected function addError(string $message, Node $node, ?string $messageId = null): bool
+    {
+        return $this->addMessage(
+            Violation::LEVEL_ERROR,
+            $message,
+            $node->getTemplateName(),
+            $node->getTemplateLine(),
+            null,
+            $messageId,
+        );
+    }
+
+    private function addMessage(
+        int $messageType,
+        string $message,
+        ?string $fileName,
+        ?int $line = null,
+        ?int $position = null,
+        ?string $messageId = null
+    ): bool {
+        $fileName ??= $this->filePath;
+
+        if (null === $fileName) {
+            return false;
+        }
+
+        $id = new ViolationId(
+            $this->getShortName(),
+            $messageId ?? ucfirst(strtolower(Violation::getLevelAsString($messageType))),
+            $line,
+            $position,
+        );
+        foreach ($this->ignoredViolations as $ignoredViolation) {
+            if ($ignoredViolation->match($id)) {
+                return false;
+            }
+        }
+
+        $violation = new Violation(
+            $messageType,
+            $message,
+            $fileName,
+            $this->getName(),
+            $id,
+        );
+
+        if (null !== $this->report) {
+            $this->report->addViolation($violation);
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Rules/Node/ConfigurableNodeRuleInterface.php
+++ b/src/Rules/Node/ConfigurableNodeRuleInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigCsFixer\Rules\Node;
+
+interface ConfigurableNodeRuleInterface extends NodeRuleInterface
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function getConfiguration(): array;
+}

--- a/src/Rules/Node/ForbiddenBlockRule.php
+++ b/src/Rules/Node/ForbiddenBlockRule.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigCsFixer\Rules\Node;
+
+use Twig\Environment;
+use Twig\Node\Node;
+
+final class ForbiddenBlockRule extends AbstractNodeRule implements ConfigurableNodeRuleInterface
+{
+    /**
+     * @param list<string> $blocks
+     */
+    public function __construct(
+        private array $blocks,
+    ) {
+    }
+
+    public function getConfiguration(): array
+    {
+        return [
+            'blocks' => $this->blocks,
+        ];
+    }
+
+    public function enterNode(Node $node, Environment $env): Node
+    {
+        $blockName = $node->getNodeTag();
+
+        if (null === $blockName) {
+            return $node;
+        }
+
+        if (!\in_array($blockName, $this->blocks, true)) {
+            return $node;
+        }
+
+        $this->addError(
+            sprintf('Block "%s" is not allowed.', $blockName),
+            $node,
+        );
+
+        return $node;
+    }
+}

--- a/src/Rules/Node/ForbiddenFilterRule.php
+++ b/src/Rules/Node/ForbiddenFilterRule.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigCsFixer\Rules\Node;
+
+use Twig\Environment;
+use Twig\Node\Expression\FilterExpression;
+use Twig\Node\Node;
+
+final class ForbiddenFilterRule extends AbstractNodeRule implements ConfigurableNodeRuleInterface
+{
+    /**
+     * @param list<string> $filters
+     */
+    public function __construct(
+        private array $filters,
+    ) {
+    }
+
+    public function getConfiguration(): array
+    {
+        return [
+            'filters' => $this->filters,
+        ];
+    }
+
+    public function enterNode(Node $node, Environment $env): Node
+    {
+        if (!$node instanceof FilterExpression) {
+            return $node;
+        }
+
+        $filterName = $node->getNode('filter')->getAttribute('value');
+
+        if (!\is_string($filterName)) {
+            return $node;
+        }
+
+        if (!\in_array($filterName, $this->filters, true)) {
+            return $node;
+        }
+
+        $this->addError(
+            sprintf('Filter "%s" is not allowed.', $filterName),
+            $node,
+        );
+
+        return $node;
+    }
+}

--- a/src/Rules/Node/ForbiddenFunctionRule.php
+++ b/src/Rules/Node/ForbiddenFunctionRule.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigCsFixer\Rules\Node;
+
+use Twig\Environment;
+use Twig\Node\Expression\FunctionExpression;
+use Twig\Node\Node;
+
+final class ForbiddenFunctionRule extends AbstractNodeRule implements ConfigurableNodeRuleInterface
+{
+    /**
+     * @param list<string> $functions
+     */
+    public function __construct(
+        private array $functions,
+    ) {
+    }
+
+    public function getConfiguration(): array
+    {
+        return [
+            'functions' => $this->functions,
+        ];
+    }
+
+    public function enterNode(Node $node, Environment $env): Node
+    {
+        if (!$node instanceof FunctionExpression) {
+            return $node;
+        }
+
+        $functionName = $node->getAttribute('name');
+
+        if (!\is_string($functionName)) {
+            return $node;
+        }
+
+        if (!\in_array($functionName, $this->functions, true)) {
+            return $node;
+        }
+
+        $this->addError(
+            sprintf('Function "%s" is not allowed.', $functionName),
+            $node,
+        );
+
+        return $node;
+    }
+}

--- a/src/Rules/Node/NodeRuleInterface.php
+++ b/src/Rules/Node/NodeRuleInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigCsFixer\Rules\Node;
+
+use Twig\NodeVisitor\NodeVisitorInterface;
+use TwigCsFixer\Report\Report;
+use TwigCsFixer\Report\ViolationId;
+
+interface NodeRuleInterface extends NodeVisitorInterface
+{
+    /**
+     * @param list<ViolationId> $ignoredViolations
+     */
+    public function enterFile(Report $report, string $filePath, array $ignoredViolations = []): void;
+}

--- a/src/Ruleset/Ruleset.php
+++ b/src/Ruleset/Ruleset.php
@@ -6,6 +6,8 @@ namespace TwigCsFixer\Ruleset;
 
 use TwigCsFixer\Rules\ConfigurableRuleInterface;
 use TwigCsFixer\Rules\FixableRuleInterface;
+use TwigCsFixer\Rules\Node\ConfigurableNodeRuleInterface;
+use TwigCsFixer\Rules\Node\NodeRuleInterface;
 use TwigCsFixer\Rules\RuleInterface;
 use TwigCsFixer\Standard\StandardInterface;
 
@@ -15,7 +17,7 @@ use TwigCsFixer\Standard\StandardInterface;
 final class Ruleset
 {
     /**
-     * @var array<string, RuleInterface>
+     * @var array<string, RuleInterface|NodeRuleInterface>
      */
     private array $rules = [];
 
@@ -29,14 +31,14 @@ final class Ruleset
     }
 
     /**
-     * @return list<RuleInterface>
+     * @return list<RuleInterface|NodeRuleInterface>
      */
     public function getRules(): array
     {
         if (!$this->allowNonFixableRules) {
             return array_values(array_filter(
                 $this->rules,
-                static fn (RuleInterface $rule): bool => $rule instanceof FixableRuleInterface,
+                static fn ($rule): bool => $rule instanceof FixableRuleInterface,
             ));
         }
 
@@ -46,9 +48,9 @@ final class Ruleset
     /**
      * @return $this
      */
-    public function addRule(RuleInterface $rule): self
+    public function addRule(RuleInterface|NodeRuleInterface $rule): self
     {
-        $config = $rule instanceof ConfigurableRuleInterface
+        $config = $rule instanceof ConfigurableRuleInterface || $rule instanceof ConfigurableNodeRuleInterface
             ? $rule->getConfiguration()
             : null;
         $key = $rule::class.md5(serialize($config));
@@ -61,7 +63,7 @@ final class Ruleset
     /**
      * @return $this
      */
-    public function overrideRule(RuleInterface $rule): self
+    public function overrideRule(RuleInterface|NodeRuleInterface $rule): self
     {
         $this->removeRule($rule::class);
         $this->addRule($rule);
@@ -70,7 +72,7 @@ final class Ruleset
     }
 
     /**
-     * @param class-string<RuleInterface> $class
+     * @param class-string<RuleInterface|NodeRuleInterface> $class
      *
      * @return $this
      */

--- a/src/Standard/StandardInterface.php
+++ b/src/Standard/StandardInterface.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace TwigCsFixer\Standard;
 
+use TwigCsFixer\Rules\Node\NodeRuleInterface;
 use TwigCsFixer\Rules\RuleInterface;
 
 interface StandardInterface
 {
     /**
-     * @return list<RuleInterface>
+     * @return list<RuleInterface|NodeRuleInterface>
      */
     public function getRules(): array;
 }

--- a/tests/Runner/Fixtures/Linter/forbidden_filter.twig
+++ b/tests/Runner/Fixtures/Linter/forbidden_filter.twig
@@ -1,6 +1,8 @@
-{% block content%}
+{% block content %}
     {{ 'Hello' | trans }}
     {% if isAdmin %}
         {{ 'World' | trans }}
     {% endif %}
+    {% trans %}my.key{% endtrans %}
+    {{ t('hi') }}
 {% endblock %}

--- a/tests/Runner/Fixtures/Linter/forbidden_filter.twig
+++ b/tests/Runner/Fixtures/Linter/forbidden_filter.twig
@@ -1,0 +1,6 @@
+{% block content%}
+    {{ 'Hello' | trans }}
+    {% if isAdmin %}
+        {{ 'World' | trans }}
+    {% endif %}
+{% endblock %}

--- a/tests/Runner/LinterTest.php
+++ b/tests/Runner/LinterTest.php
@@ -6,14 +6,14 @@ namespace TwigCsFixer\Tests\Runner;
 
 use Twig\Environment;
 use Twig\Error\SyntaxError;
-use Twig\Node\Expression\FilterExpression;
-use Twig\Node\Node;
 use TwigCsFixer\Cache\Manager\CacheManagerInterface;
 use TwigCsFixer\Environment\StubbedEnvironment;
 use TwigCsFixer\Exception\CannotFixFileException;
 use TwigCsFixer\Exception\CannotTokenizeException;
 use TwigCsFixer\Report\Violation;
-use TwigCsFixer\Rules\AbstractNodeVisitorRule;
+use TwigCsFixer\Rules\Node\ForbiddenBlockRule;
+use TwigCsFixer\Rules\Node\ForbiddenFilterRule;
+use TwigCsFixer\Rules\Node\ForbiddenFunctionRule;
 use TwigCsFixer\Ruleset\Ruleset;
 use TwigCsFixer\Runner\FixerInterface;
 use TwigCsFixer\Runner\Linter;
@@ -299,45 +299,19 @@ final class LinterTest extends FileTestCase
     {
         $filePath = $this->getTmpPath(__DIR__.'/Fixtures/Linter/forbidden_filter.twig');
 
-        $nodeVisitorRule = new class(['trans']) extends AbstractNodeVisitorRule {
-            /**
-             * @param list<string> $forbidden
-             */
-            public function __construct(
-                private array $forbidden,
-            ) {
-            }
-
-            public function enterNode(Node $node, Environment $env): Node
-            {
-                if (!$node instanceof FilterExpression) {
-                    return $node;
-                }
-
-                if (!\in_array($node->getNode('filter')->getAttribute('value'), $this->forbidden, true)) {
-                    return $node;
-                }
-
-                $this->addError(
-                    sprintf('Filter "%s" is not allowed.', $node->getNode('filter')->getAttribute('value')),
-                    $node,
-                );
-
-                return $node;
-            }
-        };
-
         $env = new StubbedEnvironment();
         $tokenizer = new Tokenizer($env);
         $ruleset = new Ruleset();
-        $ruleset->addRule($nodeVisitorRule);
+        $ruleset->addRule(new ForbiddenFilterRule(['trans']));
+        $ruleset->addRule(new ForbiddenBlockRule(['trans']));
+        $ruleset->addRule(new ForbiddenFunctionRule(['t']));
 
         $linter = new Linter($env, $tokenizer);
 
         $report = $linter->run([new \SplFileInfo($filePath)], $ruleset);
 
         $messages = $report->getFileViolations($filePath);
-        static::assertCount(2, $messages);
+        static::assertCount(4, $messages);
 
         $message = $messages[0];
         static::assertSame('Filter "trans" is not allowed.', $message->getMessage());
@@ -350,5 +324,17 @@ final class LinterTest extends FileTestCase
         static::assertSame(Violation::LEVEL_ERROR, $message->getLevel());
         static::assertSame($filePath, $message->getFilename());
         static::assertSame(4, $message->getLine());
+
+        $message = $messages[2];
+        static::assertSame('Block "trans" is not allowed.', $message->getMessage());
+        static::assertSame(Violation::LEVEL_ERROR, $message->getLevel());
+        static::assertSame($filePath, $message->getFilename());
+        static::assertSame(6, $message->getLine());
+
+        $message = $messages[3];
+        static::assertSame('Function "t" is not allowed.', $message->getMessage());
+        static::assertSame(Violation::LEVEL_ERROR, $message->getLevel());
+        static::assertSame($filePath, $message->getFilename());
+        static::assertSame(7, $message->getLine());
     }
 }


### PR DESCRIPTION
Fixes #246, #248 

### Introduce NodeRuleInterface

With this you can add violations based on AST nodes.

### Introduce ForbiddenFilterRule, ForbiddenBlockRule & ForbiddenFunctionRule

This can be used to disable certain filters/blocks/functions that are available during compile/runtime.

These are just some examples. People can create other NodeVisitors for other type of verifications.

For example, we have a custom `enum` function. The value passed is a FQCN. This should be validated
early on, instead of runtime. With a NodeVisitor this could be done easily during linting.

Another idea could be to verify FQCN's for `constant` function.

Or verify that a translation key exists. Or that parameters to the translation are missing.
