### PR TITLE
Allow setting custom NodeVisitor on StubbedEnvironment

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,7 +115,7 @@ $config->setCacheFile(null);
 return $config;
 ```
 
-## Token parser & Twig Extension
+## Token parser, Twig Extension & Node Visitors
 
 If you're using custom token parsers or binary/unary operators, they can be added in your config:
 
@@ -125,6 +125,7 @@ If you're using custom token parsers or binary/unary operators, they can be adde
 $config = new TwigCsFixer\Config\Config();
 $config->addTwigExtension(new App\Twig\CustomTwigExtension());
 $config->addTokenParser(new App\Twig\CustomTokenParser());
+$config->addNodeVisitor(new App\Twig\CustomNodeVisitor());
 
 return $config;
 ```

--- a/src/Command/TwigCsFixerCommand.php
+++ b/src/Command/TwigCsFixerCommand.php
@@ -129,7 +129,8 @@ final class TwigCsFixerCommand extends Command
     {
         $twig = new StubbedEnvironment(
             $config->getTwigExtensions(),
-            $config->getTokenParsers()
+            $config->getTokenParsers(),
+            $config->getNodeVisitors()
         );
         $tokenizer = new Tokenizer($twig);
         $linter = new Linter($twig, $tokenizer, $config->getCacheManager());

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -6,6 +6,7 @@ namespace TwigCsFixer\Config;
 
 use Symfony\Component\Finder\Finder;
 use Twig\Extension\ExtensionInterface;
+use Twig\NodeVisitor\NodeVisitorInterface;
 use Twig\TokenParser\TokenParserInterface;
 use TwigCsFixer\Cache\Manager\CacheManagerInterface;
 use TwigCsFixer\File\Finder as TwigCsFinder;
@@ -38,6 +39,11 @@ final class Config
      * @var list<TokenParserInterface>
      */
     private array $tokenParsers = [];
+
+    /**
+     * @var list<NodeVisitorInterface>
+     */
+    private array $nodeVisitors = [];
 
     private bool $allowNonFixableRules = false;
 
@@ -144,6 +150,24 @@ final class Config
     public function getTokenParsers(): array
     {
         return $this->tokenParsers;
+    }
+
+    /**
+     * @return $this
+     */
+    public function addNodeVisitor(NodeVisitorInterface $nodeVisitor): self
+    {
+        $this->nodeVisitors[] = $nodeVisitor;
+
+        return $this;
+    }
+
+    /**
+     * @return list<NodeVisitorInterface>
+     */
+    public function getNodeVisitors(): array
+    {
+        return $this->nodeVisitors;
     }
 
     /**

--- a/src/Environment/StubbedEnvironment.php
+++ b/src/Environment/StubbedEnvironment.php
@@ -16,6 +16,7 @@ use Twig\Environment;
 use Twig\Extension\ExtensionInterface;
 use Twig\Extra\Cache\TokenParser\CacheTokenParser;
 use Twig\Loader\ArrayLoader;
+use Twig\NodeVisitor\NodeVisitorInterface;
 use Twig\TokenParser\TokenParserInterface;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
@@ -48,10 +49,12 @@ final class StubbedEnvironment extends Environment
     /**
      * @param ExtensionInterface[]   $customTwigExtensions
      * @param TokenParserInterface[] $customTokenParsers
+     * @param NodeVisitorInterface[] $customNodeVisitors
      */
     public function __construct(
         array $customTwigExtensions = [],
-        array $customTokenParsers = []
+        array $customTokenParsers = [],
+        array $customNodeVisitors = [],
     ) {
         parent::__construct(new ArrayLoader());
 
@@ -63,6 +66,10 @@ final class StubbedEnvironment extends Environment
 
         foreach ($customTokenParsers as $customTokenParser) {
             $this->addTokenParser($customTokenParser);
+        }
+
+        foreach ($customNodeVisitors as $customNodeVisitor) {
+            $this->addNodeVisitor($customNodeVisitor);
         }
     }
 

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TwigCsFixer\Tests\Config;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Twig\NodeVisitor\TranslationNodeVisitor;
 use Symfony\Bridge\Twig\TokenParser\DumpTokenParser;
 use Symfony\Bridge\Twig\TokenParser\TransTokenParser;
 use Symfony\Component\Finder\Finder;
@@ -84,6 +85,18 @@ final class ConfigTest extends TestCase
         $config->addTokenParser($tokenParser2);
 
         static::assertSame([$tokenParser1, $tokenParser2], $config->getTokenParsers());
+    }
+
+    public function testConfigNodeVisitors(): void
+    {
+        $config = new Config();
+
+        static::assertSame([], $config->getNodeVisitors());
+
+        $nodeVisitor1 = new TranslationNodeVisitor();
+        $config->addNodeVisitor($nodeVisitor1);
+
+        static::assertSame([$nodeVisitor1], $config->getNodeVisitors());
     }
 
     public function testConfigTwigExtensions(): void

--- a/tests/Environment/Fixtures/node_visitor.html.twig
+++ b/tests/Environment/Fixtures/node_visitor.html.twig
@@ -1,0 +1,1 @@
+{{ 'Hello, World!' | upper }}


### PR DESCRIPTION
This is already supported and used by Twig when doing a Parse.

See #249