### PR TITLE
fix(rules): revert TrailingCommaMultiLineRule

### DIFF
--- a/src/Standard/TwigCsFixer.php
+++ b/src/Standard/TwigCsFixer.php
@@ -6,7 +6,6 @@ namespace TwigCsFixer\Standard;
 
 use TwigCsFixer\Rules\Delimiter\BlockNameSpacingRule;
 use TwigCsFixer\Rules\Function\IncludeFunctionRule;
-use TwigCsFixer\Rules\Punctuation\TrailingCommaMultiLineRule;
 use TwigCsFixer\Rules\Punctuation\TrailingCommaSingleLineRule;
 use TwigCsFixer\Rules\String\HashQuoteRule;
 use TwigCsFixer\Rules\String\SingleQuoteRule;
@@ -31,7 +30,6 @@ final class TwigCsFixer implements StandardInterface
             new IncludeFunctionRule(),
             new IndentRule(),
             new SingleQuoteRule(),
-            new TrailingCommaMultiLineRule(),
             new TrailingCommaSingleLineRule(),
             new TrailingSpaceRule(),
         ];

--- a/tests/Standard/TwigCsFixerTest.php
+++ b/tests/Standard/TwigCsFixerTest.php
@@ -11,7 +11,6 @@ use TwigCsFixer\Rules\Function\IncludeFunctionRule;
 use TwigCsFixer\Rules\Operator\OperatorNameSpacingRule;
 use TwigCsFixer\Rules\Operator\OperatorSpacingRule;
 use TwigCsFixer\Rules\Punctuation\PunctuationSpacingRule;
-use TwigCsFixer\Rules\Punctuation\TrailingCommaMultiLineRule;
 use TwigCsFixer\Rules\Punctuation\TrailingCommaSingleLineRule;
 use TwigCsFixer\Rules\String\HashQuoteRule;
 use TwigCsFixer\Rules\String\SingleQuoteRule;
@@ -41,7 +40,6 @@ final class TwigCsFixerTest extends TestCase
             new IncludeFunctionRule(),
             new IndentRule(),
             new SingleQuoteRule(),
-            new TrailingCommaMultiLineRule(),
             new TrailingCommaSingleLineRule(),
             new TrailingSpaceRule(),
         ], $standard->getRules());


### PR DESCRIPTION
Fixes #257 #256 

Temporary disable this rule (too buggy for now).