### PR TITLE
Introduce ValidConstantFunctionRule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -115,6 +115,10 @@ To use these rules, you have to [allow non-fixable rules](configuration.md#non-f
   Ensures some functions are not used. Options are:
     - `function`: the name of the forbidden functions.
 
+- **ValidConstantRule**:
+
+  Ensures constant function is used on defined constant strings.
+
 ### Configurable rules
 
 Some rules are configurable, those rule are implementing `\TwigCsFixer\Rules\ConfigurableRuleInterface`.

--- a/src/Rules/Node/ValidConstantFunctionRule.php
+++ b/src/Rules/Node/ValidConstantFunctionRule.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigCsFixer\Rules\Node;
+
+use Twig\Environment;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Expression\FunctionExpression;
+use Twig\Node\Node;
+
+final class ValidConstantFunctionRule extends AbstractNodeRule
+{
+    public function enterNode(Node $node, Environment $env): Node
+    {
+        if (!$node instanceof FunctionExpression) {
+            return $node;
+        }
+
+        $functionName = $node->getAttribute('name');
+        if ('constant' !== $functionName) {
+            return $node;
+        }
+
+        $arguments = $node->getNode('arguments');
+
+        if (1 !== $arguments->count()) {
+            return $node;
+        }
+
+        if (!$arguments->getNode('0') instanceof ConstantExpression) {
+            $this->addError(
+                'Function "constant" expects a constant (string value) as argument.',
+                $node,
+                'ArgumentNotConstant'
+            );
+
+            return $node;
+        }
+
+        $constant = $arguments->getNode('0')->getAttribute('value');
+
+        if (!\is_string($constant)) {
+            return $node;
+        }
+
+        if (\defined($constant)) {
+            return $node;
+        }
+
+        if ('::class' === strtolower(substr($constant, -7))) {
+            $this->addError(
+                sprintf('You cannot use the Twig function "constant()" to access "%s". You could provide an object and call constant("class", $object) or use the class name directly as a string.', $constant),
+                $node,
+                'ClassConstant'
+            );
+
+            return $node;
+        }
+
+        $this->addError(
+            sprintf('Constant "%s" is undefined.', $constant),
+            $node,
+            'ConstantUndefined'
+        );
+
+        return $node;
+    }
+}

--- a/src/Rules/Node/ValidConstantFunctionRule.php
+++ b/src/Rules/Node/ValidConstantFunctionRule.php
@@ -9,6 +9,9 @@ use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Expression\FunctionExpression;
 use Twig\Node\Node;
 
+/**
+ * Ensures constant function is used on defined constant strings.
+ */
 final class ValidConstantFunctionRule extends AbstractNodeRule
 {
     public function enterNode(Node $node, Environment $env): Node
@@ -23,23 +26,16 @@ final class ValidConstantFunctionRule extends AbstractNodeRule
         }
 
         $arguments = $node->getNode('arguments');
-
         if (1 !== $arguments->count()) {
             return $node;
         }
 
-        if (!$arguments->getNode('0') instanceof ConstantExpression) {
-            $this->addError(
-                'Function "constant" expects a constant (string value) as argument.',
-                $node,
-                'ArgumentNotConstant'
-            );
-
+        $argument = $arguments->getNode('0');
+        if (!$argument instanceof ConstantExpression) {
             return $node;
         }
 
-        $constant = $arguments->getNode('0')->getAttribute('value');
-
+        $constant = $argument->getAttribute('value');
         if (!\is_string($constant)) {
             return $node;
         }
@@ -54,15 +50,13 @@ final class ValidConstantFunctionRule extends AbstractNodeRule
                 $node,
                 'ClassConstant'
             );
-
-            return $node;
+        } else {
+            $this->addError(
+                sprintf('Constant "%s" is undefined.', $constant),
+                $node,
+                'ConstantUndefined'
+            );
         }
-
-        $this->addError(
-            sprintf('Constant "%s" is undefined.', $constant),
-            $node,
-            'ConstantUndefined'
-        );
 
         return $node;
     }

--- a/tests/Rules/Node/ValidConstantFunction/ValidConstantFunctionRuleTest.php
+++ b/tests/Rules/Node/ValidConstantFunction/ValidConstantFunctionRuleTest.php
@@ -9,12 +9,13 @@ use TwigCsFixer\Tests\Rules\AbstractRuleTestCase;
 
 final class ValidConstantFunctionRuleTest extends AbstractRuleTestCase
 {
+    public const SOME_CONSTANT = 'Foo';
+
     public function testRule(): void
     {
         $this->checkRule(new ValidConstantFunctionRule(), [
-            'ValidConstantFunction.ConstantUndefined:6' => 'Constant "ThisDoesNotExist::SomeKey" is undefined.',
-            'ValidConstantFunction.ArgumentNotConstant:7' => 'Function "constant" expects a constant (string value) as argument.',
-            'ValidConstantFunction.ClassConstant:8' => 'You cannot use the Twig function "constant()" to access "ThisDoesNotExist::class". You could provide an object and call constant("class", $object) or use the class name directly as a string.',
+            'ValidConstantFunction.ConstantUndefined:7' => 'Constant "ThisDoesNotExist::SomeKey" is undefined.',
+            'ValidConstantFunction.ClassConstant:9' => 'You cannot use the Twig function "constant()" to access "ThisDoesNotExist::class". You could provide an object and call constant("class", $object) or use the class name directly as a string.',
         ]);
     }
 }

--- a/tests/Rules/Node/ValidConstantFunction/ValidConstantFunctionRuleTest.php
+++ b/tests/Rules/Node/ValidConstantFunction/ValidConstantFunctionRuleTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigCsFixer\Tests\Rules\Node\ValidConstantFunction;
+
+use TwigCsFixer\Rules\Node\ValidConstantFunctionRule;
+use TwigCsFixer\Tests\Rules\AbstractRuleTestCase;
+
+final class ValidConstantFunctionRuleTest extends AbstractRuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->checkRule(new ValidConstantFunctionRule(), [
+            'ValidConstantFunction.ConstantUndefined:6' => 'Constant "ThisDoesNotExist::SomeKey" is undefined.',
+            'ValidConstantFunction.ArgumentNotConstant:7' => 'Function "constant" expects a constant (string value) as argument.',
+            'ValidConstantFunction.ClassConstant:8' => 'You cannot use the Twig function "constant()" to access "ThisDoesNotExist::class". You could provide an object and call constant("class", $object) or use the class name directly as a string.',
+        ]);
+    }
+}

--- a/tests/Rules/Node/ValidConstantFunction/ValidConstantFunctionRuleTest.twig
+++ b/tests/Rules/Node/ValidConstantFunction/ValidConstantFunctionRuleTest.twig
@@ -1,0 +1,9 @@
+{% block content %}
+    {{ constant('DateTimeInterface::ATOM') }}
+    {{ constant('DATE_ATOM') }}
+    {{ constant('class', someObject) }}
+
+    {{ constant('ThisDoesNotExist::SomeKey') }}
+    {{ constant(someVar) }}
+    {{ constant('ThisDoesNotExist::class') }}
+{% endblock %}

--- a/tests/Rules/Node/ValidConstantFunction/ValidConstantFunctionRuleTest.twig
+++ b/tests/Rules/Node/ValidConstantFunction/ValidConstantFunctionRuleTest.twig
@@ -1,6 +1,7 @@
 {% block content %}
     {{ constant('DateTimeInterface::ATOM') }}
     {{ constant('DATE_ATOM') }}
+    {{ constant('TwigCsFixer\\Tests\\Rules\\Node\\ValidConstantFunction\\ValidConstantFunctionRuleTest::SOME_CONSTANT') }}
     {{ constant('class', someObject) }}
 
     {{ constant('ThisDoesNotExist::SomeKey') }}


### PR DESCRIPTION
Fixes #248

This rule can be used to verify correct usage of the `constant` function.

- It requires that the constant (first argument) is passed as string literal. 
- It checks if a `::class` reference was done
- It checks if the constant exists