### PR TITLE
doc: add note about PHAR and versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ this is the recommended way because it will autoload everything you need.
 You can always fetch the stable version as a Phar archive through the following
 link with the `VERSION` you're looking for:
 
+> [!WARNING]
+> Until a stable version for the `3.x` branch is published, you have to use a RC version like `3.0.0-rc-3`,
+> see the available versions on the [releases](https://github.com/VincentLanglet/Twig-CS-Fixer/releases) page.
+
 ```bash
 wget -c https://github.com/VincentLanglet/Twig-CS-Fixer/releases/download/VERSION/twig-cs-fixer.phar
 ```


### PR DESCRIPTION
The GitHub visual diff doesn't show the actual result, it will be rendered like this: https://github.com/alexislefebvre/Twig-CS-Fixer/tree/patch-1?tab=readme-ov-file#as-a-phar