### PR TITLE
Fix deprecation in ForbiddenFilterRule.php

### DIFF
--- a/src/Rules/Node/ForbiddenFilterRule.php
+++ b/src/Rules/Node/ForbiddenFilterRule.php
@@ -35,7 +35,9 @@ final class ForbiddenFilterRule extends AbstractNodeRule implements Configurable
             return $node;
         }
 
-        $filterName = $node->getNode('filter')->getAttribute('value');
+        $filterName = $node->hasAttribute('name')
+            ? $node->getAttribute('name')
+            : $node->getNode('filter')->getAttribute('value'); // BC for twig/twig < 3.12
         if (!\in_array($filterName, $this->filters, true)) {
             return $node;
         }


### PR DESCRIPTION
> Deprecate the `filter` node of `FilterExpression`

Needed for Twig 3.12.0

See https://github.com/twigphp/Twig/pull/4184

Do we need to bump the minimum required Twig version?