### PR TITLE
docs: use h3 in standards list in rules.md

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -163,7 +163,8 @@ new TwigCsFixer\Rules\Whitespace\IndentRule(3);
 
 ## Standards
 
-**Twig**:
+### Twig Rules
+
 - DelimiterSpacingRule
 - NamedArgumentNameRule
 - NamedArgumentSeparatorRule
@@ -173,7 +174,8 @@ new TwigCsFixer\Rules\Whitespace\IndentRule(3);
 - PunctuationSpacingRule
 - VariableNameRule
 
-**TwigCsFixer**:
+### TwigCsFixer
+
 - Twig
 - BlankEOFRule
 - BlockNameSpacingRule
@@ -187,7 +189,8 @@ new TwigCsFixer\Rules\Whitespace\IndentRule(3);
 - TrailingCommaSingleLineRule
 - TrailingSpaceRule
 
-**Symfony**:
+#### Symfony
+
 - Twig
 - DirectoryNameRule
 - FileNameRule


### PR DESCRIPTION
I'm suggesting to use titles here, because it allows to link directly to a given standard set of rules...

Also this will increase visibility in the Table of Content (on GitHub or ... in the sidebar 👼 )