### PR TITLE
feat: introduce new rule to fix var comment

### DIFF
--- a/src/Rules/Comment/CommentTypeRule.php
+++ b/src/Rules/Comment/CommentTypeRule.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigCsFixer\Rules\Comment;
+
+use TwigCsFixer\Rules\AbstractFixableRule;
+use TwigCsFixer\Token\Token;
+
+/**
+ * Change a variable comment "{# @var var_name type" with "{% types var_name: 'type' %}".
+ */
+final class CommentTypeRule extends AbstractFixableRule
+{
+    protected function process(int $tokenPosition, array $tokens): void
+    {
+        var_dump($tokenPosition, $tokens);
+        $token = $tokens[$tokenPosition];
+        var_dump($token);
+
+        // Listen COMMENT_TEXT_TYPE https://github.com/VincentLanglet/Twig-CS-Fixer/blob/main/src/Token/Token.php#L42
+        // If the value is not @var return
+
+        if (!$this->isTokenMatching($token, Token::COMMENT_START_TYPE, '@var')) {
+            return;
+        }
+
+        // is warning the proper violation "level" here?
+        $fixer = $this->addFixableWarning(
+            'Variable comment declaration must be used via types tag instead of comment.',
+            $token
+        );
+        if (null === $fixer) {
+            return;
+        }
+
+        $tokenValue = $token->getValue();
+        var_dump($tokenValue);
+
+        $firstTextType = $this->findNext(Token::COMMENT_TEXT_TYPE, $tokens, $tokenPosition);
+        var_dump($firstTextType);
+        $secondTextType = $this->findNext(Token::COMMENT_TEXT_TYPE, $tokens, $tokenPosition);
+        var_dump($secondTextType);
+        $thirdTextType = $this->findNext(Token::COMMENT_TEXT_TYPE, $tokens, $tokenPosition);
+        var_dump($thirdTextType);
+
+        // TODO
+
+        /*
+
+        Else parse the whole comment, looking for COMMENT_START_TYPE before and COMMENT_END_TYPE
+
+COMMENT_START_TYPE
+COMMENT_WHITESPACE_TYPE
+COMMENT_TEXT_TYPE
+COMMENT_WHITESPACE_TYPE
+COMMENT_TEXT_TYPE
+COMMENT_WHITESPACE_TYPE
+COMMENT_TEXT_TYPE
+COMMENT_WHITESPACE_TYPE
+COMMENT_END_TYPE
+
+        Rewrite it
+
+{% types foo: 'bar' %}
+where foo is the 2nd COMMENT_TEXT_TYPE and bar the third.
+
+        */
+
+        $variableName = $secondTextType;
+        $variableType = $thirdTextType;
+
+        $fixer->replaceToken(
+            $tokenPosition,
+            \sprintf("{% types %s: '%s'", $variableName, $variableType)
+        );
+    }
+}

--- a/tests/Rules/Comment/CommentType/CommentTypeRuleTest.fixed.twig
+++ b/tests/Rules/Comment/CommentType/CommentTypeRuleTest.fixed.twig
@@ -1,0 +1,5 @@
+{% types foo_bar: 'boolean' %}
+{% types bar_baz: 'integer|null' %}
+{% types admin: '\App\Entity\Admin' %}
+{% types user: '\App\Entity\User|null' %}
+{% types users: '\App\Entity\User[]' %}

--- a/tests/Rules/Comment/CommentType/CommentTypeRuleTest.php
+++ b/tests/Rules/Comment/CommentType/CommentTypeRuleTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigCsFixer\Tests\Rules\Comment\CommentType;
+
+use TwigCsFixer\Rules\Comment\CommentTypeRule;
+use TwigCsFixer\Tests\Rules\AbstractRuleTestCase;
+
+final class CommentTypeRuleTest extends AbstractRuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->checkRule(
+            [
+                new CommentTypeRule(),
+            ],
+            [
+                // TODO: compute proper file lines/elements
+                'CommentType.Error:1:4' => 'Variable comment declaration must be used via types tag instead of comment.',
+                'CommentType.Error:2:4' => 'Variable comment declaration must be used via types tag instead of comment.',
+                'CommentType.Error:3:4' => 'Variable comment declaration must be used via types tag instead of comment.',
+                'CommentType.Error:4:4' => 'Variable comment declaration must be used via types tag instead of comment.',
+                'CommentType.Error:5:4' => 'Variable comment declaration must be used via types tag instead of comment.',
+            ]
+        );
+    }
+}

--- a/tests/Rules/Comment/CommentType/CommentTypeRuleTest.twig
+++ b/tests/Rules/Comment/CommentType/CommentTypeRuleTest.twig
@@ -1,0 +1,5 @@
+{# @var foo_bar boolean #}
+{# @var bar_baz integer|null #}
+{# @var admin \App\Entity\Admin #}
+{# @var user \App\Entity\User|null #}
+{# @var users \App\Entity\User[] #}


### PR DESCRIPTION
> [!WARNING]
> WIP, just to make stuff rolling on my side

---

close https://github.com/VincentLanglet/Twig-CS-Fixer/issues/375
- https://twig.symfony.com/doc/3.x/tags/types.html
- https://speakerdeck.com/fabpot/symfonycon-vienna-2025-twig-still-relevant-in-2025?slide=25

this PR introduce a new rule to fix comment var comment declaration to the new types tag

---

for now I am trying mostly to understand the project itself and token parsing etc
feel free to comment nonetheless 