### PR TITLE
fix: link to actions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PHP Version](https://poser.pugx.org/vincentlanglet/twig-cs-fixer/require/php)](https://packagist.org/packages/vincentlanglet/twig-cs-fixer)
 [![Latest Stable Version](https://poser.pugx.org/vincentlanglet/twig-cs-fixer/v)](https://github.com/VincentLanglet/Twig-CS-Fixer/releases/latest)
 [![License](https://poser.pugx.org/vincentlanglet/twig-cs-fixer/license)](https://github.com/VincentLanglet/Twig-CS-Fixer/blob/main/LICENCE)
-[![Actions Status](https://github.com/VincentLanglet/Twig-CS-Fixer/workflows/Test/badge.svg)](https://github.com/VincentLanglet/Twig-CS-Fixer/actions/workflows/test.yml?query=branch%3Amain)
+[![Actions Status](https://github.com/VincentLanglet/Twig-CS-Fixer/workflows/Test/badge.svg)](https://github.com/VincentLanglet/Twig-CS-Fixer/actions/workflows/test.yaml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/VincentLanglet/Twig-CS-Fixer/branch/main/graph/badge.svg)](https://codecov.io/gh/VincentLanglet/Twig-CS-Fixer/branch/main)
 [![Infection MSI](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FVincentLanglet%2FTwig-CS-Fixer%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/VincentLanglet/Twig-CS-Fixer/main)
 


### PR DESCRIPTION
The previous link lead to another repo.

It targets the `main` branch otherwise it would show results from PR.

There are 2 options here:

- show only the test workflow (used in this PR): https://github.com/VincentLanglet/Twig-CS-Fixer/actions/workflows/test.yaml?query=branch%3Amain
- show all the workflows: https://github.com/VincentLanglet/Twig-CS-Fixer/actions?query=branch%3Amain