### PR TITLE
Output a list of fixed files

### DIFF
--- a/src/Console/Command/TwigCsFixerCommand.php
+++ b/src/Console/Command/TwigCsFixerCommand.php
@@ -100,10 +100,6 @@ final class TwigCsFixerCommand extends Command
             return self::INVALID;
         }
 
-        foreach ($report->getFixedFiles() as $fixedFile) {
-            $output->writeln(\sprintf(' <fg=red>[FIX] %s</>', $fixedFile));
-        }
-
         return 0 === $report->getTotalErrors() ? self::SUCCESS : self::FAILURE;
     }
 

--- a/src/Report/Reporter/TextReporter.php
+++ b/src/Report/Reporter/TextReporter.php
@@ -106,6 +106,10 @@ final class TextReporter implements ReporterInterface
         } else {
             $io->success($summaryString);
         }
+
+        foreach ($report->getFixedFiles() as $fixedFile) {
+            $output->writeln(\sprintf(' [FIXED] %s</>', $fixedFile));
+        }
     }
 
     /**

--- a/tests/Console/Command/TwigCsFixerCommandTest.php
+++ b/tests/Console/Command/TwigCsFixerCommandTest.php
@@ -82,7 +82,7 @@ final class TwigCsFixerCommandTest extends FileTestCase
 
         $commandTester = new CommandTester($command);
         $commandTester->execute([
-            'paths' => [$tmpPath = $this->getTmpPath(__DIR__.'/Fixtures')],
+            'paths' => [$this->getTmpPath(__DIR__.'/Fixtures')],
             '--fix' => true,
         ]);
 
@@ -91,10 +91,6 @@ final class TwigCsFixerCommandTest extends FileTestCase
         static::assertStringContainsString(TestHelper::getOsPath('directory/error/file.twig'), $display);
         static::assertStringContainsString(
             '[ERROR] Files linted: 3, notices: 0, warnings: 0, errors: 1',
-            $display
-        );
-        static::assertStringContainsString(
-            \sprintf('[FIX] %s', TestHelper::getOsPath("{$tmpPath}/directory/fixable/file.twig")),
             $display
         );
         static::assertSame(Command::FAILURE, $commandTester->getStatusCode());

--- a/tests/Report/Reporter/TextReporterTest.php
+++ b/tests/Report/Reporter/TextReporterTest.php
@@ -251,4 +251,19 @@ final class TextReporterTest extends TestCase
         yield ['[ERROR] Files linted: 1, notices: 0, warnings: 0, errors: 1', Violation::LEVEL_ERROR];
         yield ['[ERROR] Files linted: 1, notices: 0, warnings: 0, errors: 1', Violation::LEVEL_FATAL];
     }
+
+    public function testDisplayPathOfFixedFile(): void
+    {
+        $textFormatter = new TextReporter();
+
+        $file = TestHelper::getOsPath(__DIR__.'/Fixtures/file.twig');
+        $report = new Report([new \SplFileInfo($file)]);
+        $report->addFixedFile($file);
+
+        $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+        $textFormatter->display($output, $report, null, false);
+
+        $text = $output->fetch();
+        static::assertStringContainsString("[FIXED] {$file}", $text);
+    }
 }


### PR DESCRIPTION
Closes #421

With this PR, when running with the `fix`/`f` input option, we're now outputting a list of the fixed files like so:

```
> vendor/bin/twig-cs-fixer fix

 [OK] Files linted: 100, notices: 0, warnings: 0, errors: 0

 [FIX] /path/to/template/foo.html.twig
 [FIX] /path/to/template/bar.html.twig
```

This is for instance handy when running the tools again before pushing commits as you now notice that changes happened.