### PR TITLE
Keep quotes on negative integer hash keys

### DIFF
--- a/src/Rules/Literal/HashQuoteRule.php
+++ b/src/Rules/Literal/HashQuoteRule.php
@@ -97,6 +97,8 @@ final class HashQuoteRule extends AbstractFixableRule implements ConfigurableRul
 
     private function isInteger(string $value): bool
     {
-        return $value === (string) (int) $value;
+        // A negative integer like `-1` is not a valid unquoted hash key,
+        // so it must keep its quotes.
+        return $value === (string) (int) $value && !str_starts_with($value, '-');
     }
 }

--- a/tests/Rules/Literal/HashQuote/HashQuoteRuleTest.fixed.twig
+++ b/tests/Rules/Literal/HashQuote/HashQuoteRuleTest.fixed.twig
@@ -14,6 +14,8 @@
 {% set float = {12.3: a} %} {# It's the same than `{123: a}` #}
 {% set float = {'12.3': a} %}
 
+{% set negativeNumber = {'-1': a} %} {# `-1` is not a valid unquoted hash key #}
+
 {% set needQuote = {'data-foo': a} %}
 
 {% set namedArgument = foo(bar: true, baz: false) %}

--- a/tests/Rules/Literal/HashQuote/HashQuoteRuleTest.twig
+++ b/tests/Rules/Literal/HashQuote/HashQuoteRuleTest.twig
@@ -14,6 +14,8 @@
 {% set float = {12.3: a} %} {# It's the same than `{123: a}` #}
 {% set float = {'12.3': a} %}
 
+{% set negativeNumber = {'-1': a} %} {# `-1` is not a valid unquoted hash key #}
+
 {% set needQuote = {'data-foo': a} %}
 
 {% set namedArgument = foo(bar: true, baz: false) %}

--- a/tests/Rules/Literal/HashQuote/HashQuoteRuleTest.with.fixed.twig
+++ b/tests/Rules/Literal/HashQuote/HashQuoteRuleTest.with.fixed.twig
@@ -14,6 +14,8 @@
 {% set float = {12.3: a} %} {# It's the same than `{123: a}` #}
 {% set float = {'12.3': a} %}
 
+{% set negativeNumber = {'-1': a} %} {# `-1` is not a valid unquoted hash key #}
+
 {% set needQuote = {'data-foo': a} %}
 
 {% set namedArgument = foo(bar: true, baz: false) %}


### PR DESCRIPTION
Fix #451, generated with the help of Claude