### PR TITLE
Fix upgrade guide diffs for 2.x to 3.0

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -51,7 +51,7 @@ If you never implemented a custom rule, nothing else changed. Otherwise, ...
 
 ```diff
 - $this->isTokenMatching($token, $type, $value)
-+ $token->isTokenMatching($type, $value)
++ $token->isMatching($type, $value)
 ```
 
 ```diff
@@ -67,12 +67,12 @@ If you never implemented a custom rule, nothing else changed. Otherwise, ...
 + $tokens->findPrevious($type, $start)
 
 - $this->findPrevious($type, $tokens, $start, true)
-+ $tokens->findPrevious($type, $start, null, true)
++ $tokens->findPrevious($type, $start, 0, true)
 ```
 
 ```diff
 - protected function process(int $tokenPosition, array $tokens): void;
-+ protected function process(int $tokenIndex, Tokens $tokens): ?int;
++ protected function process(int $tokenIndex, Tokens $tokens): void;
 ```
 
 ### AbstractSpacingRule


### PR DESCRIPTION
# Fix upgrade guide diffs for 2.x to 3.0

## Summary

This PR addresses some differences I found between the docs and Twig-CS-Fixer while following the upgrade guide from 2.x to 3.0 for my project.

It updates function names, parameters, and return types to the correct or default values for 3.0.

Thanks for maintaining this project.