### PR TITLE
Add named arguments option to IncludeFunctionRule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -37,9 +37,10 @@
   Ensures that hash key are not unnecessarily quoted. Options are:
     - `useQuote`: hash key must be preferred quoted (default false).
 
-- **IncludeFunctionRule**:
+- **IncludeFunctionRule** (Configurable):
 
-  Ensures that include function is used instead of include tag.
+  Ensures that include function is used instead of include tag. Options are:
+    - `namedArguments`: use named arguments for `with_context` and `ignore_missing` instead of positional ones (default false).
 
 - **IndentRule** (Configurable):
 

--- a/src/Rules/Function/IncludeFunctionRule.php
+++ b/src/Rules/Function/IncludeFunctionRule.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TwigCsFixer\Rules\Function;
 
 use TwigCsFixer\Rules\AbstractFixableRule;
+use TwigCsFixer\Rules\ConfigurableRuleInterface;
 use TwigCsFixer\Token\Token;
 use TwigCsFixer\Token\Tokens;
 use Webmozart\Assert\Assert;
@@ -12,8 +13,19 @@ use Webmozart\Assert\Assert;
 /**
  * Ensures that the include function is used instead of include tag.
  */
-final class IncludeFunctionRule extends AbstractFixableRule
+final class IncludeFunctionRule extends AbstractFixableRule implements ConfigurableRuleInterface
 {
+    public function __construct(private readonly bool $namedArguments = false)
+    {
+    }
+
+    public function getConfiguration(): array
+    {
+        return [
+            'namedArguments' => $this->namedArguments,
+        ];
+    }
+
     protected function process(int $tokenIndex, Tokens $tokens): void
     {
         $token = $tokens->get($tokenIndex);
@@ -69,14 +81,24 @@ final class IncludeFunctionRule extends AbstractFixableRule
         }
 
         $endInclude = ') '.str_replace('%}', '}}', $tokens->get($closingTag)->getValue());
-        if ($ignoreMissing) {
-            $endInclude = ', true'.$endInclude;
-        }
-        if ($ignoreMissing || $withoutContext) {
-            $endInclude = \sprintf(', %s', $withoutContext ? 'false' : 'true').$endInclude;
+        if ($this->namedArguments) {
+            // Named arguments let us skip default-valued and placeholder arguments.
+            if ($ignoreMissing) {
+                $endInclude = ', ignore_missing=true'.$endInclude;
+            }
+            if ($withoutContext) {
+                $endInclude = ', with_context=false'.$endInclude;
+            }
+        } else {
+            if ($ignoreMissing) {
+                $endInclude = ', true'.$endInclude;
+            }
+            if ($ignoreMissing || $withoutContext) {
+                $endInclude = \sprintf(', %s', $withoutContext ? 'false' : 'true').$endInclude;
 
-            if (!$withVariable) {
-                $endInclude = ', []'.$endInclude;
+                if (!$withVariable) {
+                    $endInclude = ', []'.$endInclude;
+                }
             }
         }
 

--- a/tests/Rules/Function/IncludeFunction/IncludeFunctionRuleTest.named.fixed.twig
+++ b/tests/Rules/Function/IncludeFunction/IncludeFunctionRuleTest.named.fixed.twig
@@ -1,0 +1,16 @@
+{{ include('template.html') }}
+{{ include(['template_a.html', 'template_b.html'], {'foo': 'bar'}, with_context=false, ignore_missing=true) }}
+{{ include('template.html', with_context=false) }}
+{{ include('template.html', vars) }}
+{{ include('template.html', vars, with_context=false) }}
+{{ include('template.html', {'foo': 'bar'}) }}
+{{ include('template.html', {'foo': 'bar'}, with_context=false) }}
+{{ include(some_var) }}
+{{ include(ajax ? 'ajax.html' : 'not_ajax.html') }}
+{{ include('template.html', ignore_missing=true) }}
+{{ include('template.html', {'foo': 'bar'}, ignore_missing=true) }}
+{{ include('template.html', with_context=false, ignore_missing=true) }}
+{{ include(['template_a.html', 'template_b.html']) }}
+{{ include(['template_a.html', 'template_b.html'], with_context=false) }}
+{{- include('template.html') ~}}
+{{~ include('template.html') -}}

--- a/tests/Rules/Function/IncludeFunction/IncludeFunctionRuleTest.php
+++ b/tests/Rules/Function/IncludeFunction/IncludeFunctionRuleTest.php
@@ -10,6 +10,18 @@ use TwigCsFixer\Test\AbstractRuleTestCase;
 
 final class IncludeFunctionRuleTest extends AbstractRuleTestCase
 {
+    public function testConfiguration(): void
+    {
+        static::assertSame(
+            ['namedArguments' => false],
+            (new IncludeFunctionRule())->getConfiguration()
+        );
+        static::assertSame(
+            ['namedArguments' => true],
+            (new IncludeFunctionRule(namedArguments: true))->getConfiguration()
+        );
+    }
+
     public function testRule(): void
     {
         $this->checkRule(
@@ -36,6 +48,36 @@ final class IncludeFunctionRuleTest extends AbstractRuleTestCase
                 'IncludeFunction.Error:15:5' => 'Include function must be used instead of include tag.',
                 'IncludeFunction.Error:16:5' => 'Include function must be used instead of include tag.',
             ]
+        );
+    }
+
+    public function testRuleWithNamedArguments(): void
+    {
+        $this->checkRule(
+            [
+                new IncludeFunctionRule(namedArguments: true),
+                // Extra rule for a better diff
+                new PunctuationSpacingRule(),
+            ],
+            [
+                'IncludeFunction.Error:1:4' => 'Include function must be used instead of include tag.',
+                'IncludeFunction.Error:2:4' => 'Include function must be used instead of include tag.',
+                'IncludeFunction.Error:3:4' => 'Include function must be used instead of include tag.',
+                'IncludeFunction.Error:4:4' => 'Include function must be used instead of include tag.',
+                'IncludeFunction.Error:5:4' => 'Include function must be used instead of include tag.',
+                'IncludeFunction.Error:6:4' => 'Include function must be used instead of include tag.',
+                'IncludeFunction.Error:7:4' => 'Include function must be used instead of include tag.',
+                'IncludeFunction.Error:8:4' => 'Include function must be used instead of include tag.',
+                'IncludeFunction.Error:9:4' => 'Include function must be used instead of include tag.',
+                'IncludeFunction.Error:10:4' => 'Include function must be used instead of include tag.',
+                'IncludeFunction.Error:11:4' => 'Include function must be used instead of include tag.',
+                'IncludeFunction.Error:12:4' => 'Include function must be used instead of include tag.',
+                'IncludeFunction.Error:13:4' => 'Include function must be used instead of include tag.',
+                'IncludeFunction.Error:14:4' => 'Include function must be used instead of include tag.',
+                'IncludeFunction.Error:15:5' => 'Include function must be used instead of include tag.',
+                'IncludeFunction.Error:16:5' => 'Include function must be used instead of include tag.',
+            ],
+            fixedFilePath: __DIR__.'/IncludeFunctionRuleTest.named.fixed.twig',
         );
     }
 }


### PR DESCRIPTION
Salut!

Just thought it would be nice to have named arguments when applying the `IncludeFunctionRule` rule. Defaults to `false` to avoid breaking changes.

Named args usually provide better readability than long list of booleans. 

Happy to get your feedback on this. 